### PR TITLE
Fixed a bug that prevented custom filters from working inside a List

### DIFF
--- a/Editor/PickleAttributeDrawer.cs
+++ b/Editor/PickleAttributeDrawer.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Pickle.ObjectProviders;
 using UnityEditor;
 using UnityEngine;
-using Pickle.ObjectProviders;
-using System.Collections;
-using System.Text.RegularExpressions;
-using System.Reflection;
 
 namespace Pickle.Editor
 {
@@ -198,9 +199,17 @@ namespace Pickle.Editor
                     if (arrayFieldInfo == null)
                         return null;
 
-                    var array = arrayFieldInfo.GetValue(owner) as System.Array;
+                    object arrayLike = arrayFieldInfo.GetValue(owner);
+                    var array = arrayLike as System.Array;
                     if (array == null)
-                        return null;
+                    {
+                        Type type = arrayLike.GetType();
+                        if (type.IsGenericType && type.GetGenericTypeDefinition().IsAssignableFrom(typeof(List<>)))
+                            array = type.GetField("_items", FLAGS_ALL)?.GetValue(arrayLike) as System.Array;
+
+                        if (array == null)
+                            return null;
+                    }
 
                     owner = array.GetValue(index);
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mpozek.pickle",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "unity": "2020.3",
   "displayName":  "Pickle",
   "description": "A better Object picker for Unity"


### PR DESCRIPTION
I encountered a little bug with the serialization of a List of objects with a FilterMethodName, which would break the inspector, this fixes it so that this works:

```csharp
[Serializable]
public class MyComponent : MonoBehaviour
{
  [SerializeField] private List<MyClass> instances;
}
```

```csharp
[Serializable]
public class MyClass
{
  [Pickle(FilterMethodName = nameof(IsValid)] // This custom filter would break the inspector when inside a List
  [SerializeField] internal MonoBehaviour composant;

  protected bool IsValid(ObjectTypePair _) => true;
}
```